### PR TITLE
Simplify visibilitymap and intensitymap internal

### DIFF
--- a/ext/ComradeBaseEnzymeExt.jl
+++ b/ext/ComradeBaseEnzymeExt.jl
@@ -5,18 +5,6 @@ using Enzyme: @parallel
 
 const EnzymeThreads = ComradeBase.ThreadsEx{:enzyme}
 
-function ComradeBase.intensitymap_analytic(s::ComradeBase.AbstractModel, dims::ComradeBase.AbstractRectiGrid{D, <:EnzymeThreads}) where {D}
-    img = ComradeBase.allocate_imgmap(s, dims)
-    ComradeBase.intensitymap_analytic!(img, s)
-    return img
-end
-
-function ComradeBase.intensitymap_analytic(s::ComradeBase.AbstractModel, dims::ComradeBase.UnstructuredDomain{D, <:EnzymeThreads}) where {D}
-    img = ComradeBase.allocate_imgmap(s, dims)
-    ComradeBase.intensitymap_analytic!(img, s)
-    return img
-end
-
 function ComradeBase.intensitymap_analytic!(img::IntensityMap{T, N, D, <:ComradeBase.AbstractRectiGrid{D, <:EnzymeThreads}}, s::ComradeBase.AbstractModel) where {T, N, D}
     dx, dy = ComradeBase.pixelsizes(img)
     g = ComradeBase.domainpoints(img)

--- a/ext/ComradeBaseOhMyThreadsExt.jl
+++ b/ext/ComradeBaseOhMyThreadsExt.jl
@@ -7,17 +7,6 @@ else
     using .OhMyThreads
 end
 
-function ComradeBase.intensitymap_analytic(s::ComradeBase.AbstractModel, dims::ComradeBase.AbstractRectiGrid{D, <:OhMyThreads.Scheduler}) where {D}
-    dx = step(dims.X)
-    dy = step(dims.Y)
-    g = domainpoints(dims)
-    f = Base.Fix1(ComradeBase.intensity_point, s)
-    img = tmap(g; scheduler=executor(dims)) do p
-        f(p)*dx*dy
-    end
-    return img
-end
-
 function ComradeBase.intensitymap_analytic!(img::IntensityMap{T,N,D,<:ComradeBase.AbstractRectiGrid{D, <:OhMyThreads.Scheduler}}, s::ComradeBase.AbstractModel) where {T,N,D}
     dims = axisdims(img)
     dx = step(dims.X)
@@ -28,13 +17,6 @@ function ComradeBase.intensitymap_analytic!(img::IntensityMap{T,N,D,<:ComradeBas
         img[I] = f(g[I])*dx*dy
     end
     return nothing
-end
-
-function ComradeBase.intensitymap_analytic(s::ComradeBase.AbstractModel, dims::ComradeBase.UnstructuredDomain{D, <:OhMyThreads.Scheduler}) where {D}
-    g = domainpoints(dims)
-    f = Base.Fix1(ComradeBase.intensity_point, s)
-    img = tmap(f, g; scheduler=executor(dims))
-    return img
 end
 
 

--- a/src/images/dim_image.jl
+++ b/src/images/dim_image.jl
@@ -168,24 +168,11 @@ end
     rebuild(img, data, dims, refdims, name, metadata)
 end
 
-function intensitymap_analytic(s::AbstractModel, dims::AbstractRectiGrid)
-    dx = step(dims.X)
-    dy = step(dims.Y)
-    img = intensity_point.(Ref(s), domainpoints(dims)).*dx.*dy
-    return IntensityMap(img, dims)
-end
-
 function intensitymap_analytic!(img::IntensityMap, s::AbstractModel)
     dx, dy = pixelsizes(img)
     g = domainpoints(img)
     img .= intensity_point.(Ref(s), g).*dx.*dy
     return nothing
-end
-
-function intensitymap_analytic(s::AbstractModel, dims::AbstractRectiGrid{D, <:ThreadsEx}) where {D}
-    img = allocate_imgmap(s, dims)
-    intensitymap_analytic!(img, s)
-    return img
 end
 
 function intensitymap_analytic!(

--- a/src/images/images.jl
+++ b/src/images/images.jl
@@ -25,6 +25,13 @@ end
 @inline intensitymap(::IsAnalytic, m::AbstractModel, dims::AbstractDomain)  = intensitymap_analytic(m, dims)
 @inline intensitymap(::NotAnalytic, m::AbstractModel, dims::AbstractDomain) = intensitymap_numeric(m, dims)
 
+function intensitymap_analytic(s::AbstractModel, dims::AbstractDomain)
+    img = allocate_imgmap(s, dims)
+    intensitymap_analytic!(img, s)
+    return img
+end
+
+
 
 """
     intensitymap!(img::AbstractIntensityMap, mode;, executor = SequentialEx())

--- a/src/unstructured_map.jl
+++ b/src/unstructured_map.jl
@@ -71,24 +71,12 @@ Base.@propagate_inbounds function Base.getindex(x::UnstructuredMap, I)
     UnstructuredMap(parent(x)[I], newdims)
 end
 
-function intensitymap_analytic(m::AbstractModel, dims::UnstructuredDomain)
-    g = domainpoints(dims)
-    img = intensity_point.(Ref(m), g)
-    return img
-end
-
 function intensitymap_analytic!(img::UnstructuredMap{T, <:Any, <:AbstractSingleDomain}, s::AbstractModel) where {T}
     g = domainpoints(img)
     img .= intensity_point.(Ref(s), g)
     return nothing
 end
 
-
-function intensitymap_analytic(s::AbstractModel, dims::UnstructuredDomain{D, <:ThreadsEx}) where {D}
-    img = UnstructuredMap(zeros(eltype(dims.X), size(dims)), dims)
-    intensitymap_analytic!(img, s)
-    return img
-end
 
 function intensitymap_analytic!(
     img::UnstructuredMap{T,<:Any,<:UnstructuredDomain{D, <:ThreadsEx{S}}},


### PR DESCRIPTION
Because we are moving to solely support enzyme I can greatly simplify the internals of visbilitymap_analytic and intensitymap_analytic and remove a large number of redundant methods.