### PR TITLE
Use `complex(...)` instead of `Complex{...}`.

### DIFF
--- a/src/domain.jl
+++ b/src/domain.jl
@@ -60,7 +60,7 @@ end
 end
 
 function allocate_vismap(p, m::AbstractModel, g::AbstractSingleDomain{D, E}) where {D, E}
-    M = similartype(p, E, Complex{eltype(g)})
+    M = similartype(p, E, complex(eltype(g)))
     return allocate_map(M, g)
 end
 


### PR DESCRIPTION
This is useful for Reactant, where `eltype(g)` might be `TracedRNumber{Float64}` and `Complex{TracedRNumber{Float64}}` doesn't exist.